### PR TITLE
Add network output normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ network.create_layer(neurons: 2)
 network.initialize_edges
 
 network.run([0.5]*10)
-=> [3, 0.1]
+=> [0.029312230751356326, 0.0040701377158961285]
 
 ## Improvements / Bugs
 Improvements and bugs are listed as issues in the gem repository.

--- a/lib/network.rb
+++ b/lib/network.rb
@@ -27,9 +27,13 @@ class SimpleNeuralNetwork
 
     attr_accessor :inputs
 
+    attr_writer :normalization_function
+
     def initialize
       @layers = []
       @inputs = []
+
+      @normalization_function = method(:default_normalization_function)
     end
 
     # Run an input set against the neural network.
@@ -45,7 +49,7 @@ class SimpleNeuralNetwork
 
       # Get output from last layer. It recursively depends on layers before it.
       @layers[-1].get_output.map do |output|
-        normalize_output(output)
+        @normalization_function.call(output)
       end
     end
 
@@ -79,12 +83,16 @@ class SimpleNeuralNetwork
       @layers.each(&:initialize_neuron_edges)
     end
 
+    def reset_normalization_function
+      @normalization_function = method(:default_normalization_function)
+    end
+
     private
 
-    # Apply a normalization function to the network output
-    # By default, we apply the standard logistic sigmoid function
+    # The default normalization function for the network output
+    # The standard logistic sigmoid function
     # f(x) = 1 / (1 + e^(-x))
-    def normalize_output(output)
+    def default_normalization_function(output)
       1 / (1 + (Math::E ** (-1 * output)))
     end
   end

--- a/lib/network.rb
+++ b/lib/network.rb
@@ -44,7 +44,9 @@ class SimpleNeuralNetwork
       @inputs = inputs
 
       # Get output from last layer. It recursively depends on layers before it.
-      @layers[-1].get_output
+      @layers[-1].get_output.map do |output|
+        normalize_output(output)
+      end
     end
 
     # Returns the number of input nodes
@@ -75,6 +77,15 @@ class SimpleNeuralNetwork
     # Initializes with random weights between -5 and 5
     def initialize_edges
       @layers.each(&:initialize_neuron_edges)
+    end
+
+    private
+
+    # Apply a normalization function to the network output
+    # By default, we apply the standard logistic sigmoid function
+    # f(x) = 1 / (1 + e^(-x))
+    def normalize_output(output)
+      1 / (1 + (Math::E ** (-1 * output)))
     end
   end
 end


### PR DESCRIPTION
Closes #4 

- Adds a default network output normalization method: https://en.wikipedia.org/wiki/Logistic_function
- Allows setting arbitrary normalization lambdas.