### PR TITLE
Allow custom edge weight and neuron bias initialization via lambdas

### DIFF
--- a/lib/network.rb
+++ b/lib/network.rb
@@ -29,11 +29,16 @@ class SimpleNeuralNetwork
 
     attr_writer :normalization_function
 
+    attr_accessor :edge_initialization_function
+    attr_accessor :neuron_bias_initialization_function
+
     def initialize
       @layers = []
       @inputs = []
 
       @normalization_function = method(:default_normalization_function)
+      @edge_initialization_function = method(:default_edge_initialization_function)
+      @neuron_bias_initialization_function = method(:default_neuron_bias_initialization_function)
     end
 
     # Run an input set against the neural network.
@@ -94,6 +99,14 @@ class SimpleNeuralNetwork
     # f(x) = 1 / (1 + e^(-x))
     def default_normalization_function(output)
       1 / (1 + (Math::E ** (-1 * output)))
+    end
+
+    def default_edge_initialization_function
+      rand(-5..5)
+    end
+
+    def default_neuron_bias_initialization_function
+      0
     end
   end
 end

--- a/lib/neuron.rb
+++ b/lib/neuron.rb
@@ -1,27 +1,23 @@
 class SimpleNeuralNetwork
   class Neuron
-    # Define the minimum and maximum edge weight
-    EDGE_RANGE = -5..5
-
     attr_accessor :bias
-
-    # The neuron parent layer
-    attr_accessor :layer
 
     # A neuron's edges connect it to the #{layer.next_layer.size} neurons of the next layer
     attr_accessor :edges
 
-    def initialize(layer)
+    def initialize(layer:)
       @layer = layer
-      @bias = 0
+      @bias = layer.network.neuron_bias_initialization_function.call
       @edges = []
       @value = nil
     end
 
     # A neuron should have one edge per neuron in the next layer
     def initialize_edges(next_layer_size)
+      init_function = @layer.network.edge_initialization_function
+
       next_layer_size.times do
-        @edges << rand(EDGE_RANGE)
+        @edges << init_function.call
       end
     end
   end


### PR DESCRIPTION
Closes #3 

Adds two new setters, `edge_initialization_function=` and `neuron_bias_initialization_function=`. These functions allow you to control how edges and neuron biases are initialized. Both functions have defaults. The edge default is `rand(-5..5)`, and the bias default is `0`