### PR TITLE
150x improved performance for large data sets

### DIFF
--- a/lib/network.rb
+++ b/lib/network.rb
@@ -41,9 +41,13 @@ class SimpleNeuralNetwork
     # Accepts an array of input integers between 0 and 1
     # Input array length must be equal to the size of the first layer.
     # Returns an array of outputs.
-    def run(inputs)
-      unless inputs.size == input_size && inputs.all? { |input| input >= 0 && input <= 1 }
-        raise InvalidInputError.new("Invalid input passed to Network#run")
+    #
+    # skip_validation: Skips validations that may be expensive for large sets
+    def run(inputs, skip_validation: false)
+      unless skip_validation
+        unless inputs.size == input_size && inputs.all? { |input| input >= 0 && input <= 1 }
+          raise InvalidInputError.new("Invalid input passed to Network#run")
+        end
       end
 
       @inputs = inputs
@@ -82,6 +86,12 @@ class SimpleNeuralNetwork
 
     def reset_normalization_function
       @normalization_function = method(:default_normalization_function)
+    end
+
+    def clear_edge_caches
+      @layers.each do |layer|
+        layer.clear_edge_cache
+      end
     end
 
     # Serializes the neural network into a JSON string. This can later be deserialized back into a Network object

--- a/simple_neural_network.rspec
+++ b/simple_neural_network.rspec
@@ -10,4 +10,6 @@ Gem::Specification.new do |s|
   s.files       += Dir['lib/*.rb']
   s.homepage    = 'https://github.com/d12/SimpleNeuralNetwork'
   s.license     = 'MIT'
+
+  s.add_dependency "nmatrix", "~> 0.2"
 end

--- a/test/lib/network_test.rb
+++ b/test/lib/network_test.rb
@@ -107,6 +107,39 @@ class NetworkTest < Minitest::Test
     assert output == [31]
   end
 
+  def test_does_not_apply_edge_weight_changes_if_cache_not_busted
+    @network.edge_initialization_function = lambda { 5 }
+
+    @network.create_layer(neurons: 1)
+    @network.create_layer(neurons: 1)
+    @network.create_layer(neurons: 1)
+
+    output = @network.run([1])
+    assert output == [31]
+
+    @network.layers[0].neurons[0].edges = [1]
+
+    output = @network.run([1])
+    assert output == [31]
+  end
+
+  def test_applies_edge_weight_changes_if_cache_busted
+    @network.edge_initialization_function = lambda { 5 }
+
+    @network.create_layer(neurons: 1)
+    @network.create_layer(neurons: 1)
+    @network.create_layer(neurons: 1)
+
+    output = @network.run([1])
+    assert output == [31]
+
+    @network.layers[0].neurons[0].edges[0] += 5
+    @network.clear_edge_caches
+
+    output = @network.run([1])
+    assert output == [56]
+  end
+
   def test_serialize_generates_valid_json
     @network.create_layer(neurons: 1)
     @network.create_layer(neurons: 1)


### PR DESCRIPTION
Drastically improve performance of Network#run for large data sets.

Testing script:

```ruby
network = SimpleNeuralNetwork::Network.new

network.create_layer(neurons: 10240)
network.create_layer(neurons: 20)
network.create_layer(neurons: 20)
network.create_layer(neurons: 6)

srand(50)
input = Array.new(10240) { rand.round(2) }

RubyProf.start

100.times do
  network.run(input, skip_validation: true)
end

result = RubyProf.stop
```

Before: 9.69 seconds
After: 0.06 seconds

### Optimizations

- Switched from manual matrix multiplication to [NMatrix](https://github.com/SciRuby/nmatrix) C extensions for linear algebra. 
- Maintain a cache of the edge weights matrix. It's created once on initialization, and can be busted with `Network#clear_edge_caches`
- Added a `skip_validations` kwarg to `Network#run` that skips the range validations for the inputs. This saves a lot of time for networks with large input sizes.