### PR TITLE
Remove nmatrix dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+# For development
+
+source "https://rubygems.org"
+
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,17 @@
+PATH
+  remote: .
+  specs:
+    simple_neural_network (0.2.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  simple_neural_network!
+
+BUNDLED WITH
+   2.1.4

--- a/lib/layer.rb
+++ b/lib/layer.rb
@@ -1,5 +1,5 @@
 require_relative "neuron"
-require "nmatrix"
+require "matrix"
 
 class SimpleNeuralNetwork
   class Layer
@@ -42,9 +42,9 @@ class SimpleNeuralNetwork
         #              + ...
         #             ) + self.neurons[i].bias
         prev_output = prev_layer.get_output
-        prev_output_matrix = NMatrix.new([prev_output.length, 1], prev_output, dtype: :float64)
+        prev_output_matrix = Vector[*prev_output]
 
-        result = (edge_matrix.dot(prev_output_matrix)).each_with_index.map do |val, i|
+        result = (edge_matrix * prev_output_matrix).each_with_index.map do |val, i|
           val + @neurons[i].bias
         end
 
@@ -65,7 +65,7 @@ class SimpleNeuralNetwork
 
       @edge_matrix ||= begin
         elements = prev_layer.neurons.map{|a| a.edges}
-        NMatrix.new([elements.count, elements[0].count], elements.flatten, dtype: :float64).transpose
+        Matrix[*elements].transpose
       end
     end
 

--- a/simple_neural_network.gemspec
+++ b/simple_neural_network.gemspec
@@ -10,6 +10,4 @@ Gem::Specification.new do |s|
   s.files       += Dir['lib/*.rb']
   s.homepage    = 'https://github.com/d12/SimpleNeuralNetwork'
   s.license     = 'MIT'
-
-  s.add_dependency "nmatrix", "~> 0.2"
 end

--- a/simple_neural_network.rspec
+++ b/simple_neural_network.rspec
@@ -10,6 +10,4 @@ Gem::Specification.new do |s|
   s.files       += Dir['lib/*.rb']
   s.homepage    = 'https://github.com/d12/SimpleNeuralNetwork'
   s.license     = 'MIT'
-
-  s.add_dependency "nmatrix", "~> 0.2"
 end


### PR DESCRIPTION
nmatrix is unmaintained and depends on versions of GCC that can't be installed on modern macs. Let's just migrate to the builtin Matrix library. It's a little slower but way less of a pain to use.